### PR TITLE
Pcap update

### DIFF
--- a/lib_test/test_iperf.ml
+++ b/lib_test/test_iperf.ml
@@ -169,7 +169,7 @@ module Test_iperf (B : Vnetif_backends.Backend) = struct
 
     let server_ready, server_ready_u = Lwt.wait () in
     let server_done, server_done_u = Lwt.wait () in
-    let timeout = 120.0 in
+    let timeout = 240.0 in
 
     Lwt.pick [
       (Lwt_unix.sleep timeout >>= fun () -> (* timeout *)

--- a/lib_test/vnetif_common.ml
+++ b/lib_test/vnetif_common.ml
@@ -41,7 +41,7 @@ sig
   (** Add a listener function to the backend *)
   val create_backend_listener : backend -> (buffer -> unit io) -> id
   (** Disable a listener function *)
-  val disable_backend_listener : backend -> id -> unit
+  val disable_backend_listener : backend -> id -> unit io
   (** Records pcap data from the backend while running the specified function. Disables the pcap recorder when the function exits. *)
   val record_pcap : backend -> string -> (unit -> unit Lwt.t) -> unit Lwt.t
 end
@@ -84,7 +84,7 @@ module VNETIF_STACK ( B : Vnetif_backends.Backend) : VNETIF_STACK = struct
     | `Ok id -> (B.set_listen_fn backend id listenf); id
 
   let disable_backend_listener backend id =
-    B.set_listen_fn backend id (fun buf -> Lwt.return_unit)
+    B.unregister_and_flush backend id
 
   let create_pcap_recorder backend channel =
     let header_buf = Cstruct.create Pcap.sizeof_pcap_header in
@@ -118,7 +118,7 @@ module VNETIF_STACK ( B : Vnetif_backends.Backend) : VNETIF_STACK = struct
     Lwt_io.with_file ~mode:Lwt_io.output pcap_file (fun oc ->
         create_pcap_recorder backend oc >>= fun recorder_id ->
         fn () >>= fun () ->
-        disable_backend_listener backend recorder_id;
+        disable_backend_listener backend recorder_id >>= fun () ->
         Lwt.return_unit
       )
 end

--- a/opam
+++ b/opam
@@ -42,7 +42,7 @@ depends: [
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}
   "mirage-flow" {test}
-  "mirage-vnetif" {test}
+  "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}
   "pcap-format" {test}
   "lwt" {>= "2.4.7"}


### PR DESCRIPTION
- Update iperf test to 240 sec timeout (seems to run slower on circleci)
- Update to latest mirage-vnetif and add temporary fix for pcap recording race
